### PR TITLE
fix: 時給・内訳欄の固定表示とレスポンシブレイアウトを改善 #22

### DIFF
--- a/src/components/ResultDisplay.tsx
+++ b/src/components/ResultDisplay.tsx
@@ -5,109 +5,207 @@ import type { CalculationResult } from '../types';
 import { formatCurrency, formatNumber } from '../utils/calculations';
 
 interface ResultDisplayProps {
-  result: CalculationResult;
-  onSaveToHistory?: () => void;
-  isSaving?: boolean;
+    result: CalculationResult;
+    onSaveToHistory?: () => void;
+    isSaving?: boolean;
 }
 
-const ResultDisplay: React.FC<ResultDisplayProps> = ({ result, onSaveToHistory, isSaving = false }) => {
-  return (
-    <Box sx={{ display: 'flex', alignItems: 'center', gap: 3, flexWrap: 'wrap' }}>
-      {/* 時給表示 */}
-      <Box sx={{ textAlign: 'center', minWidth: 200 }}>
-        <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 0.5 }}>
-          あなたの時給
-        </Typography>
-        <Typography variant="h3" sx={{ fontWeight: 'bold' }}>
-          {formatCurrency(result.hourlyWage)}
-        </Typography>
-        <Typography variant="body2">
-          / 時間
-        </Typography>
-      </Box>
-
-      <Divider orientation="vertical" flexItem sx={{ borderColor: 'rgba(255, 255, 255, 0.3)' }} />
-
-      {/* 内訳 */}
-      <Box sx={{ flex: 1, minWidth: 300 }}>
-        <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold' }}>
-          内訳
-        </Typography>
-        
-        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, alignItems: 'flex-end' }}>
-          <Box sx={{ minWidth: 120 }}>
-            <Typography variant="caption">実質年収</Typography>
-            <Typography variant="body1" sx={{ fontWeight: 'bold' }}>
-              {formatCurrency(result.actualAnnualIncome)}
-            </Typography>
-          </Box>
-          
-          <Box sx={{ minWidth: 120 }}>
-            <Typography variant="caption">実質月収</Typography>
-            <Typography variant="body1" sx={{ fontWeight: 'bold' }}>
-              {formatCurrency(result.actualMonthlyIncome)}
-            </Typography>
-          </Box>
-          
-          <Box sx={{ minWidth: 120 }}>
-            <Typography variant="caption">年間労働時間</Typography>
-            <Typography variant="body1" sx={{ fontWeight: 'bold' }}>
-              {formatNumber(result.totalWorkingHours)}時間
-            </Typography>
-          </Box>
-          
-          <Box sx={{ minWidth: 100 }}>
-            <Typography variant="caption">年間休日</Typography>
-            <Typography variant="body1" sx={{ fontWeight: 'bold' }}>
-              {formatNumber(result.totalAnnualHolidays)}日
-            </Typography>
-          </Box>
-          
-          {/* 保存ボタン */}
-          {result.hourlyWage > 0 && onSaveToHistory && (
-            <Box sx={{ ml: 'auto', minWidth: 120 }}>
-              <Button
-                variant="contained"
-                size="small"
-                startIcon={<SaveIcon />}
-                onClick={onSaveToHistory}
-                disabled={isSaving}
-                sx={{
-                  backgroundColor: isSaving ? 'rgba(255, 255, 255, 0.05)' : 'rgba(255, 255, 255, 0.15)',
-                  color: 'inherit',
-                  fontWeight: 'bold',
-                  borderRadius: 2,
-                  px: 2,
-                  py: 1,
-                  boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)',
-                  border: '1px solid rgba(255, 255, 255, 0.3)',
-                  '&:hover:not(:disabled)': {
-                    backgroundColor: 'rgba(255, 255, 255, 0.25)',
-                    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.2)',
-                    transform: 'translateY(-1px)',
-                  },
-                  '&:disabled': {
-                    color: 'rgba(255, 255, 255, 0.5)',
-                  },
-                  transition: 'all 0.2s ease-in-out',
-                }}
-              >
-                {isSaving ? '保存中...' : '履歴に保存'}
-              </Button>
+const ResultDisplay: React.FC<ResultDisplayProps> = ({
+    result,
+    onSaveToHistory,
+    isSaving = false,
+}) => {
+    return (
+        <Box
+            sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 4,
+                flexWrap: 'wrap',
+            }}
+        >
+            {/* 時給表示 */}
+            <Box sx={{ textAlign: 'center', minWidth: 200 }}>
+                <Typography variant="h6" sx={{ fontWeight: 'bold', mb: 0.5 }}>
+                    あなたの時給
+                </Typography>
+                <Typography variant="h3" sx={{ fontWeight: 'bold' }}>
+                    {formatCurrency(result.hourlyWage)}
+                </Typography>
             </Box>
-          )}
-        </Box>
-      </Box>
 
-      {result.hourlyWage === 0 && (
-        <Box sx={{ ml: 'auto', p: 1.5, bgcolor: 'rgba(255, 255, 255, 0.1)', borderRadius: 1 }}>
-          <Typography variant="body2">
-            給与額と労働時間を入力してください
-          </Typography>
+            <Divider
+                orientation="vertical"
+                flexItem
+                sx={{ borderColor: 'rgba(255, 255, 255, 0.3)' }}
+            />
+
+            {/* 内訳 */}
+            <Box sx={{ flex: 1, minWidth: 300 }}>
+                <Typography
+                    variant="h6"
+                    gutterBottom
+                    sx={{ fontWeight: 'bold' }}
+                >
+                    内訳
+                </Typography>
+
+                <Box
+                    sx={{
+                        display: 'flex',
+                        flexWrap: 'nowrap',
+                        gap: { xs: 1, sm: 2 },
+                        alignItems: 'center',
+                        overflow: 'hidden',
+                    }}
+                >
+                    <Box sx={{ minWidth: { xs: 80, sm: 120 }, flex: 1 }}>
+                        <Typography variant="caption">実質年収</Typography>
+                        <Typography
+                            variant="caption"
+                            sx={{
+                                color: 'rgba(255, 255, 255, 0.8)',
+                                fontSize: '0.7rem',
+                            }}
+                        >
+                            （
+                            {Math.round(
+                                (result.actualAnnualIncome / 100000) * 10
+                            )}
+                            万円）
+                        </Typography>
+                        <Box
+                            sx={{
+                                display: 'flex',
+                                alignItems: 'baseline',
+                                gap: 1,
+                            }}
+                        >
+                            <Typography
+                                variant="body1"
+                                sx={{
+                                    fontWeight: 'bold',
+                                    fontSize: { xs: '0.9rem', sm: '1.3rem' },
+                                }}
+                            >
+                                {formatCurrency(result.actualAnnualIncome)}
+                            </Typography>
+                        </Box>
+                    </Box>
+
+                    <Box sx={{ minWidth: { xs: 70, sm: 120 }, flex: 1 }}>
+                        <Typography variant="caption">実質月収</Typography>
+                        <Typography
+                            variant="caption"
+                            sx={{
+                                color: 'rgba(255, 255, 255, 0.8)',
+                                fontSize: '0.7rem',
+                            }}
+                        >
+                            （
+                            {Math.round(
+                                (result.actualMonthlyIncome / 10000) * 10
+                            ) / 10}
+                            万円）
+                        </Typography>
+                        <Typography
+                            variant="body1"
+                            sx={{
+                                fontWeight: 'bold',
+                                fontSize: { xs: '0.9rem', sm: '1.3rem' },
+                            }}
+                        >
+                            {formatCurrency(result.actualMonthlyIncome)}
+                        </Typography>
+                    </Box>
+
+                    <Box sx={{ minWidth: { xs: 70, sm: 120 }, flex: 1 }}>
+                        <Typography variant="caption">年間労働時間</Typography>
+                        <Typography
+                            variant="body1"
+                            sx={{
+                                fontWeight: 'bold',
+                                fontSize: { xs: '0.9rem', sm: '1.3rem' },
+                            }}
+                        >
+                            {formatNumber(result.totalWorkingHours)}時間
+                        </Typography>
+                    </Box>
+
+                    <Box sx={{ minWidth: { xs: 60, sm: 100 }, flex: 1 }}>
+                        <Typography variant="caption">年間休日</Typography>
+                        <Typography
+                            variant="body1"
+                            sx={{
+                                fontWeight: 'bold',
+                                fontSize: { xs: '0.9rem', sm: '1.3rem' },
+                            }}
+                        >
+                            {formatNumber(result.totalAnnualHolidays)}日
+                        </Typography>
+                    </Box>
+
+                    {/* 保存ボタン */}
+                    {result.hourlyWage > 0 && onSaveToHistory && (
+                        <Box
+                            sx={{
+                                minWidth: { xs: 80, sm: 120 },
+                                flexShrink: 0,
+                            }}
+                        >
+                            <Button
+                                variant="contained"
+                                size="small"
+                                startIcon={<SaveIcon />}
+                                onClick={onSaveToHistory}
+                                disabled={isSaving}
+                                sx={{
+                                    backgroundColor: isSaving
+                                        ? 'rgba(255, 255, 255, 0.05)'
+                                        : 'rgba(255, 255, 255, 0.15)',
+                                    color: 'inherit',
+                                    fontWeight: 'bold',
+                                    borderRadius: 2,
+                                    px: 2,
+                                    py: 1,
+                                    boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)',
+                                    border: '1px solid rgba(255, 255, 255, 0.3)',
+                                    '&:hover:not(:disabled)': {
+                                        backgroundColor:
+                                            'rgba(255, 255, 255, 0.25)',
+                                        boxShadow:
+                                            '0 4px 12px rgba(0, 0, 0, 0.2)',
+                                        transform: 'translateY(-1px)',
+                                    },
+                                    '&:disabled': {
+                                        color: 'rgba(255, 255, 255, 0.5)',
+                                    },
+                                    transition: 'all 0.2s ease-in-out',
+                                }}
+                            >
+                                {isSaving ? '保存中...' : '履歴に保存'}
+                            </Button>
+                        </Box>
+                    )}
+                </Box>
+            </Box>
+
+            {result.hourlyWage === 0 && (
+                <Box
+                    sx={{
+                        ml: 'auto',
+                        p: 1.5,
+                        bgcolor: 'rgba(255, 255, 255, 0.1)',
+                        borderRadius: 1,
+                    }}
+                >
+                    <Typography variant="body2">
+                        給与額と労働時間を入力してください
+                    </Typography>
+                </Box>
+            )}
         </Box>
-      )}
-    </Box>
-  );
+    );
 };
 
 export default ResultDisplay;

--- a/src/components/SalaryCalculator.tsx
+++ b/src/components/SalaryCalculator.tsx
@@ -3,7 +3,6 @@ import { Box, Paper } from '@mui/material';
 import type { SalaryCalculationData, CalculationResult } from '../types';
 import BasicInputForm from './BasicInputForm';
 import OptionsForm from './OptionsForm';
-import ResultDisplay from './ResultDisplay';
 import DynamicHolidaySettings from './DynamicHolidaySettings';
 import { calculateHourlyWage } from '../utils/calculations';
 import { calculateHourlyWageWithDynamicHolidays } from '../utils/dynamicHolidayCalculations';
@@ -11,12 +10,10 @@ import { calculateHourlyWageWithDynamicHolidays } from '../utils/dynamicHolidayC
 interface SalaryCalculatorProps {
   data: SalaryCalculationData;
   onChange: (data: SalaryCalculationData) => void;
-  onSaveToHistory?: () => void;
-  isSaving?: boolean;
+  onResultChange: (result: CalculationResult) => void;
 }
 
-const SalaryCalculator: React.FC<SalaryCalculatorProps> = ({ data, onChange, onSaveToHistory, isSaving }) => {
-  const [result, setResult] = useState<CalculationResult>(() => calculateHourlyWage(data));
+const SalaryCalculator: React.FC<SalaryCalculatorProps> = ({ data, onChange, onResultChange }) => {
   const [useDynamicHolidays, setUseDynamicHolidays] = useState(true);
 
   useEffect(() => {
@@ -30,38 +27,20 @@ const SalaryCalculator: React.FC<SalaryCalculatorProps> = ({ data, onChange, onS
         } else {
           newResult = calculateHourlyWage(data);
         }
-        setResult(newResult);
+        onResultChange(newResult);
       } catch (error) {
         console.warn('動的祝日計算に失敗しました。フォールバック計算を使用します:', error);
         const fallbackResult = calculateHourlyWage(data);
-        setResult(fallbackResult);
+        onResultChange(fallbackResult);
         setUseDynamicHolidays(false);
       }
     };
 
     updateResult();
-  }, [data, useDynamicHolidays]);
+  }, [data, useDynamicHolidays, onResultChange]);
 
   return (
     <Box sx={{ width: '100%' }}>
-      {/* 計算結果を上部に固定表示 */}
-      <Paper 
-        elevation={4} 
-        sx={{ 
-          p: { xs: 2, sm: 3 },
-          mb: { xs: 2, sm: 3 },
-          borderRadius: 2,
-          bgcolor: 'primary.main',
-          color: 'primary.contrastText',
-          position: 'sticky',
-          top: { xs: 70, sm: 90 },
-          zIndex: 999,
-          mx: { xs: 0, sm: 'auto' },
-        }}
-      >
-        <ResultDisplay result={result} onSaveToHistory={onSaveToHistory} isSaving={isSaving} />
-      </Paper>
-
       {/* 入力フォーム */}
       <Box 
         sx={{ 


### PR DESCRIPTION
## 概要
画面スクロール時に時給・内訳欄が固定され、背後のコンテンツが透けて見えない問題を解決。また、実質年収・月収に万円単位での表示を追加し、レスポンシブレイアウトを改善。

## 変更点

### UI/UX改善
- ResultDisplayを固定ヘッダー領域に統合
- スクロール時の背後コンテンツ透過問題を完全解決
- 実質年収に万円単位表示を追加（例: ¥4,200,000 (420万円)）
- 実質月収に万円単位表示を追加（例: ¥350,000 (35.0万円)）

### レスポンシブ対応
- 狭い画面でも全項目が横並びで表示されるレイアウトに改善
- flexWrap: 'nowrap'で履歴保存ボタンの段落ずれを防止
- レスポンシブなminWidth設定とflex属性による均等配分

### アーキテクチャ改善
- App.tsxでcalculationResult状態を一元管理
- SalaryCalculatorコンポーネントを入力フォーム専用に簡素化
- ResultDisplayの表示責任をApp.tsxに移管

## テスト
- [x] ビルドが正常に完了することを確認
- [x] TypeScript型チェックが成功することを確認
- [x] ESLintによるコード品質チェックが成功することを確認
- [x] スクロール時に時給・内訳欄が完全に固定されることを確認
- [x] 狭い画面で全項目が横並びで表示されることを確認
- [x] 万円単位表示が正しく計算されることを確認

fixes #22