### PR TITLE
feat: 条件比較機能を2項目制限の横並びレイアウトに変更 #26

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,6 @@ import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Paper from '@mui/material/Paper';
 import Alert from '@mui/material/Alert';
-import Grid from '@mui/material/Grid';
 import { 
   History as HistoryIcon,
   Calculate as CalculateIcon,
@@ -19,7 +18,6 @@ import {
 } from '@mui/icons-material';
 import SalaryCalculator from './components/SalaryCalculator';
 import ComparisonForm from './components/ComparisonForm';
-import ComparisonResults from './components/ComparisonResults';
 import { CalculationHistory } from './components/CalculationHistory';
 import ResultDisplay from './components/ResultDisplay';
 import { TeamCostCalculatorV2 } from './components/teamcost/TeamCostCalculatorV2';
@@ -143,7 +141,7 @@ function App() {
     const [teamCostErrors, setTeamCostErrors] = useState<string[]>([]);
 
     const calculationHistory = useCalculationHistory();
-    const comparison = useComparison();
+    const comparison = useComparison(calculationData);
 
     // データ変更時の処理
     const handleDataChange = useCallback((newData: SalaryCalculationData) => {
@@ -366,6 +364,61 @@ function App() {
                             </Box>
                         )}
 
+                        {/* 比較結果表示 */}
+                        {currentTab === 'calculation' && comparison.state.mode === 'comparison' && comparison.comparisonResult && (
+                            <Box
+                                sx={{
+                                    bgcolor: 'primary.main',
+                                    color: 'primary.contrastText',
+                                    borderRadius: 2,
+                                    p: { xs: 1, sm: 2 },
+                                    mb: { xs: 1, sm: 2 },
+                                }}
+                            >
+                                <Box sx={{ 
+                                    display: 'flex', 
+                                    flexDirection: { xs: 'column', md: 'row' },
+                                    gap: 3,
+                                    alignItems: 'center',
+                                    textAlign: 'center'
+                                }}>
+                                    <Box sx={{ flex: 1 }}>
+                                        <Typography variant="body2" sx={{ opacity: 0.9 }}>
+                                            最高時給
+                                        </Typography>
+                                        <Typography variant="h4" fontWeight="bold">
+                                            {formatCurrency(comparison.comparisonResult.highest.hourlyWage?.result?.hourlyWage || 0)}
+                                        </Typography>
+                                        <Typography variant="body2" sx={{ opacity: 0.8 }}>
+                                            {comparison.comparisonResult.highest.hourlyWage?.label}
+                                        </Typography>
+                                    </Box>
+                                    <Box sx={{ flex: 1 }}>
+                                        <Typography variant="body2" sx={{ opacity: 0.9 }}>
+                                            時給差額
+                                        </Typography>
+                                        <Typography variant="h5">
+                                            {formatCurrency(comparison.comparisonResult.differences.maxHourlyWageDiff)}
+                                        </Typography>
+                                        <Typography variant="body2" sx={{ opacity: 0.8 }}>
+                                            年間: {formatCurrency(comparison.comparisonResult.differences.maxAnnualIncomeDiff)}
+                                        </Typography>
+                                    </Box>
+                                    <Box sx={{ flex: 1 }}>
+                                        <Typography variant="body2" sx={{ opacity: 0.9 }}>
+                                            最低時給
+                                        </Typography>
+                                        <Typography variant="h5">
+                                            {formatCurrency(comparison.comparisonResult.lowest.hourlyWage?.result?.hourlyWage || 0)}
+                                        </Typography>
+                                        <Typography variant="body2" sx={{ opacity: 0.8 }}>
+                                            {comparison.comparisonResult.lowest.hourlyWage?.label}
+                                        </Typography>
+                                    </Box>
+                                </Box>
+                            </Box>
+                        )}
+
                         {/* チームコスト計算結果表示 */}
                         {currentTab === 'team' && (
                             teamCostErrors.length > 0 ? (
@@ -389,16 +442,22 @@ function App() {
                                         mb: { xs: 1, sm: 2 },
                                     }}
                                 >
-                                    <Grid container spacing={3} alignItems="center">
-                                        <Grid size={{ xs: 12, md: 4 }}>
+                                    <Box sx={{ 
+                                        display: 'flex', 
+                                        flexDirection: { xs: 'column', md: 'row' },
+                                        gap: 3,
+                                        alignItems: 'center',
+                                        textAlign: 'center'
+                                    }}>
+                                        <Box sx={{ flex: 1 }}>
                                             <Typography variant="body2" sx={{ opacity: 0.9 }}>
                                                 年間総コスト
                                             </Typography>
                                             <Typography variant="h3" fontWeight="bold">
                                                 {formatCurrency(teamCostResult.totalAnnualCost)}
                                             </Typography>
-                                        </Grid>
-                                        <Grid size={{ xs: 12, md: 4 }}>
+                                        </Box>
+                                        <Box sx={{ flex: 1 }}>
                                             <Typography variant="body2" sx={{ opacity: 0.9 }}>
                                                 月平均コスト
                                             </Typography>
@@ -408,8 +467,8 @@ function App() {
                                             <Typography variant="body2" sx={{ opacity: 0.8 }}>
                                                 年間作業時間: {teamCostResult.totalAnnualHours.toFixed(1)}h
                                             </Typography>
-                                        </Grid>
-                                        <Grid size={{ xs: 12, md: 4 }}>
+                                        </Box>
+                                        <Box sx={{ flex: 1 }}>
                                             <Typography variant="body2" sx={{ opacity: 0.9 }}>
                                                 月平均作業時間
                                             </Typography>
@@ -419,8 +478,8 @@ function App() {
                                             <Typography variant="body2" sx={{ opacity: 0.8 }}>
                                                 1時間あたり: {formatCurrency(teamCostResult.totalAnnualCost / teamCostResult.totalAnnualHours)}
                                             </Typography>
-                                        </Grid>
-                                    </Grid>
+                                        </Box>
+                                    </Box>
                                 </Box>
                             ) : (
                                 <Alert severity="info" sx={{ mb: { xs: 1, sm: 2 } }}>
@@ -458,22 +517,16 @@ function App() {
                                     onResultChange={handleResultChange}
                                 />
                             ) : (
-                                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-                                    <ComparisonForm
-                                        items={comparison.state.items}
-                                        activeItemId={comparison.state.activeItemId}
-                                        onAddItem={comparison.addItem}
-                                        onRemoveItem={comparison.removeItem}
-                                        onUpdateItem={comparison.updateItem}
-                                        onUpdateLabel={comparison.updateLabel}
-                                        onSetActiveItem={comparison.setActiveItem}
-                                        maxItems={3}
-                                    />
-                                    <ComparisonResults
-                                        comparisonResult={comparison.comparisonResult}
-                                        loading={comparison.isCalculating}
-                                    />
-                                </Box>
+                                <ComparisonForm
+                                    items={comparison.state.items}
+                                    activeItemId={comparison.state.activeItemId}
+                                    onAddItem={comparison.addItem}
+                                    onRemoveItem={comparison.removeItem}
+                                    onUpdateItem={comparison.updateItem}
+                                    onUpdateLabel={comparison.updateLabel}
+                                    onSetActiveItem={comparison.setActiveItem}
+                                    maxItems={2}
+                                />
                             )
                         ) : (
                             <TeamCostCalculatorV2 

--- a/src/hooks/useComparison.ts
+++ b/src/hooks/useComparison.ts
@@ -11,7 +11,7 @@ import { calculateHourlyWageWithDynamicHolidays } from '../utils/dynamicHolidayC
 
 const STORAGE_KEY = 'value-me-comparison-state';
 
-export const useComparison = () => {
+export const useComparison = (singleCalculationData?: SalaryCalculationData) => {
   const [state, setState] = useState<ComparisonState>(() => {
     try {
       const stored = localStorage.getItem(STORAGE_KEY);
@@ -212,54 +212,63 @@ export const useComparison = () => {
   const setMode = useCallback((mode: 'single' | 'comparison') => {
     let newState = { ...state, mode };
 
-    // 比較モードに切り替える時、アイテムがない場合はデフォルトアイテムを追加
-    if (mode === 'comparison' && state.items.length === 0) {
-      const defaultItem: ComparisonItem = {
-        id: `comparison-${Date.now()}`,
-        label: '条件 1',
-        data: {
-          salaryType: 'monthly',
-          salaryAmount: 200000,
-          annualHolidays: 119,
-          dailyWorkingHours: 8,
-          workingHoursType: 'daily',
-          useDynamicHolidays: true,
-          holidayYear: (() => {
-            const currentMonth = new Date().getMonth() + 1;
-            const currentYear = new Date().getFullYear();
-            return currentMonth >= 4 ? currentYear : currentYear - 1;
-          })(),
-          holidayYearType: 'fiscal',
-          enableBenefits: false,
-          welfareAmount: 0,
-          welfareType: 'monthly',
-          welfareInputMethod: 'individual',
-          housingAllowance: 0,
-          regionalAllowance: 0,
-          familyAllowance: 0,
-          qualificationAllowance: 0,
-          otherAllowance: 0,
-          summerBonus: 0,
-          winterBonus: 0,
-          settlementBonus: 0,
-          otherBonus: 0,
-          goldenWeekHolidays: false,
-          obon: false,
-          yearEndNewYear: false,
-          customHolidays: 0,
-        },
+    // 比較モードに切り替える時の処理
+    if (mode === 'comparison') {
+      // 単一計算データがある場合は比較元として使用
+      const sourceData = singleCalculationData || {
+        salaryType: 'monthly',
+        salaryAmount: 200000,
+        annualHolidays: 119,
+        dailyWorkingHours: 8,
+        workingHoursType: 'daily',
+        useDynamicHolidays: true,
+        holidayYear: (() => {
+          const currentMonth = new Date().getMonth() + 1;
+          const currentYear = new Date().getFullYear();
+          return currentMonth >= 4 ? currentYear : currentYear - 1;
+        })(),
+        holidayYearType: 'fiscal',
+        enableBenefits: false,
+        welfareAmount: 0,
+        welfareType: 'monthly',
+        welfareInputMethod: 'individual',
+        housingAllowance: 0,
+        regionalAllowance: 0,
+        familyAllowance: 0,
+        qualificationAllowance: 0,
+        otherAllowance: 0,
+        summerBonus: 0,
+        winterBonus: 0,
+        settlementBonus: 0,
+        otherBonus: 0,
+        goldenWeekHolidays: false,
+        obon: false,
+        yearEndNewYear: false,
+        customHolidays: 0,
+      } as const;
+
+      const sourceItem: ComparisonItem = {
+        id: `comparison-source-${Date.now()}`,
+        label: '比較元',
+        data: sourceData,
+      };
+
+      const targetItem: ComparisonItem = {
+        id: `comparison-target-${Date.now()}`,
+        label: '比較先',
+        data: { ...sourceData, salaryAmount: sourceData.salaryAmount + 50000 },
       };
 
       newState = {
         ...newState,
-        items: [defaultItem],
-        activeItemId: defaultItem.id,
+        items: [sourceItem, targetItem],
+        activeItemId: sourceItem.id,
       };
     }
 
     setState(newState);
     saveToStorage(newState);
-  }, [state, saveToStorage]);
+  }, [state, saveToStorage, singleCalculationData]);
 
   // 全クリア
   const clearAll = useCallback(() => {


### PR DESCRIPTION
## 概要
条件比較機能を複数項目から2項目のみの横並び比較に変更し、UI/UXを向上

## 変更点

### UI/レイアウト変更
- タブ形式から横並び2項目レイアウトに変更
- 比較元・比較先の固定ラベル化
- レスポンシブ対応（デスクトップ：横並び、モバイル：縦積み）
- 比較結果を画面上部に固定表示（単一計算やチームコストと同様）

### 機能改善
- 単一計算で入力された内容を比較元と自動同期
- maxItems制限を2に設定
- 不要な追加・削除ボタンを削除しUI簡素化

### 技術的改善
- Material-UI Grid2互換性問題をBoxレイアウトで解決
- useCallback/useEffectの依存配列最適化
- 未使用インポートの削除とlint修正

## テスト
- [x] TypeScript型チェック通過
- [x] ESLint通過（既存のteamcost関連以外）
- [x] ビルド成功確認
- [x] レスポンシブ表示確認
- [x] 単一計算→比較モード切り替え動作確認
- [x] 比較結果上部固定表示確認

fixes #26