### PR TITLE
時給比較結果のUI改善とパーセンテージ表示機能追加 #33

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -606,6 +606,7 @@ function App() {
                                     mb: { xs: 1, sm: 2 },
                                 }}
                             >
+                                {/* 比較元・比較先の時給と年収を横並び表示 */}
                                 <Box sx={{ 
                                     display: 'flex', 
                                     flexDirection: { xs: 'column', md: 'row' },
@@ -613,7 +614,7 @@ function App() {
                                     alignItems: 'stretch',
                                     textAlign: 'center'
                                 }}>
-                                    {/* 最高時給 */}
+                                    {/* 比較元 */}
                                     <Box sx={{ 
                                         flex: 1, 
                                         display: 'flex', 
@@ -622,17 +623,17 @@ function App() {
                                         minHeight: { xs: 'auto', md: '120px' }
                                     }}>
                                         <Typography variant="body2" sx={{ opacity: 0.9, mb: 1 }}>
-                                            最高時給
+                                            {comparison.comparisonResult.items[0]?.label || '比較元'}
                                         </Typography>
-                                        <Typography variant="h4" fontWeight="bold" sx={{ mb: 0.5 }}>
-                                            {formatCurrency(comparison.comparisonResult.highest.hourlyWage?.result?.hourlyWage || 0)}
+                                        <Typography variant="h6" fontWeight="bold" sx={{ mb: 0.5 }}>
+                                            時給: {formatCurrency(comparison.comparisonResult.items[0]?.result?.hourlyWage || 0)}
                                         </Typography>
                                         <Typography variant="body2" sx={{ opacity: 0.8 }}>
-                                            {comparison.comparisonResult.highest.hourlyWage?.label}
+                                            年収: {formatCurrency(comparison.comparisonResult.items[0]?.result?.actualAnnualIncome || 0)}
                                         </Typography>
                                     </Box>
 
-                                    {/* 時給差額 */}
+                                    {/* 比較先 */}
                                     <Box sx={{ 
                                         flex: 1, 
                                         display: 'flex', 
@@ -641,17 +642,17 @@ function App() {
                                         minHeight: { xs: 'auto', md: '120px' }
                                     }}>
                                         <Typography variant="body2" sx={{ opacity: 0.9, mb: 1 }}>
-                                            時給差額
+                                            {comparison.comparisonResult.items[1]?.label || '比較先'}
                                         </Typography>
-                                        <Typography variant="h5" fontWeight="bold" sx={{ mb: 0.5 }}>
-                                            {formatCurrency(comparison.comparisonResult.differences.maxHourlyWageDiff)}
+                                        <Typography variant="h6" fontWeight="bold" sx={{ mb: 0.5 }}>
+                                            時給: {formatCurrency(comparison.comparisonResult.items[1]?.result?.hourlyWage || 0)}
                                         </Typography>
                                         <Typography variant="body2" sx={{ opacity: 0.8 }}>
-                                            {formatPercentage(comparison.comparisonResult.differences.maxHourlyWageDiffPercent)}
+                                            年収: {formatCurrency(comparison.comparisonResult.items[1]?.result?.actualAnnualIncome || 0)}
                                         </Typography>
                                     </Box>
 
-                                    {/* 最低時給 */}
+                                    {/* 差額表示 */}
                                     <Box sx={{ 
                                         flex: 1, 
                                         display: 'flex', 
@@ -660,33 +661,15 @@ function App() {
                                         minHeight: { xs: 'auto', md: '120px' }
                                     }}>
                                         <Typography variant="body2" sx={{ opacity: 0.9, mb: 1 }}>
-                                            最低時給
+                                            差額
                                         </Typography>
-                                        <Typography variant="h5" fontWeight="bold" sx={{ mb: 0.5 }}>
-                                            {formatCurrency(comparison.comparisonResult.lowest.hourlyWage?.result?.hourlyWage || 0)}
+                                        <Typography variant="h6" fontWeight="bold" sx={{ mb: 0.5 }}>
+                                            時給: {formatCurrency(comparison.comparisonResult.differences.maxHourlyWageDiff)} {formatPercentage(comparison.comparisonResult.differences.maxHourlyWageDiffPercent)}
                                         </Typography>
                                         <Typography variant="body2" sx={{ opacity: 0.8 }}>
-                                            {comparison.comparisonResult.lowest.hourlyWage?.label}
+                                            年収: {formatCurrency(comparison.comparisonResult.differences.maxAnnualIncomeDiff)} {formatPercentage(comparison.comparisonResult.differences.maxAnnualIncomeDiffPercent)}
                                         </Typography>
                                     </Box>
-                                </Box>
-
-                                {/* 年収差額セクション */}
-                                <Box sx={{ 
-                                    mt: { xs: 2, sm: 3 }, 
-                                    pt: { xs: 2, sm: 3 }, 
-                                    borderTop: '1px solid rgba(255,255,255,0.2)',
-                                    textAlign: 'center'
-                                }}>
-                                    <Typography variant="body2" sx={{ opacity: 0.9, mb: 1 }}>
-                                        年収差額
-                                    </Typography>
-                                    <Typography variant="h5" fontWeight="bold" sx={{ mb: 0.5 }}>
-                                        {formatCurrency(comparison.comparisonResult.differences.maxAnnualIncomeDiff)}
-                                    </Typography>
-                                    <Typography variant="body2" sx={{ opacity: 0.8 }}>
-                                        {formatPercentage(comparison.comparisonResult.differences.maxAnnualIncomeDiffPercent)}
-                                    </Typography>
                                 </Box>
                             </Box>
                         )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -406,6 +406,11 @@ function App() {
         }).format(amount);
     };
 
+    // パーセンテージフォーマット関数
+    const formatPercentage = (percentage: number): string => {
+        return `(${percentage.toFixed(1)}%)`;
+    };
+
     return (
         <ThemeProvider theme={theme}>
             <CssBaseline />
@@ -604,43 +609,84 @@ function App() {
                                 <Box sx={{ 
                                     display: 'flex', 
                                     flexDirection: { xs: 'column', md: 'row' },
-                                    gap: 3,
-                                    alignItems: 'center',
+                                    gap: { xs: 2, sm: 3 },
+                                    alignItems: 'stretch',
                                     textAlign: 'center'
                                 }}>
-                                    <Box sx={{ flex: 1 }}>
-                                        <Typography variant="body2" sx={{ opacity: 0.9 }}>
+                                    {/* 最高時給 */}
+                                    <Box sx={{ 
+                                        flex: 1, 
+                                        display: 'flex', 
+                                        flexDirection: 'column', 
+                                        justifyContent: 'center',
+                                        minHeight: { xs: 'auto', md: '120px' }
+                                    }}>
+                                        <Typography variant="body2" sx={{ opacity: 0.9, mb: 1 }}>
                                             最高時給
                                         </Typography>
-                                        <Typography variant="h4" fontWeight="bold">
+                                        <Typography variant="h4" fontWeight="bold" sx={{ mb: 0.5 }}>
                                             {formatCurrency(comparison.comparisonResult.highest.hourlyWage?.result?.hourlyWage || 0)}
                                         </Typography>
                                         <Typography variant="body2" sx={{ opacity: 0.8 }}>
                                             {comparison.comparisonResult.highest.hourlyWage?.label}
                                         </Typography>
                                     </Box>
-                                    <Box sx={{ flex: 1 }}>
-                                        <Typography variant="body2" sx={{ opacity: 0.9 }}>
+
+                                    {/* 時給差額 */}
+                                    <Box sx={{ 
+                                        flex: 1, 
+                                        display: 'flex', 
+                                        flexDirection: 'column', 
+                                        justifyContent: 'center',
+                                        minHeight: { xs: 'auto', md: '120px' }
+                                    }}>
+                                        <Typography variant="body2" sx={{ opacity: 0.9, mb: 1 }}>
                                             時給差額
                                         </Typography>
-                                        <Typography variant="h5">
+                                        <Typography variant="h5" fontWeight="bold" sx={{ mb: 0.5 }}>
                                             {formatCurrency(comparison.comparisonResult.differences.maxHourlyWageDiff)}
                                         </Typography>
                                         <Typography variant="body2" sx={{ opacity: 0.8 }}>
-                                            年間: {formatCurrency(comparison.comparisonResult.differences.maxAnnualIncomeDiff)}
+                                            {formatPercentage(comparison.comparisonResult.differences.maxHourlyWageDiffPercent)}
                                         </Typography>
                                     </Box>
-                                    <Box sx={{ flex: 1 }}>
-                                        <Typography variant="body2" sx={{ opacity: 0.9 }}>
+
+                                    {/* 最低時給 */}
+                                    <Box sx={{ 
+                                        flex: 1, 
+                                        display: 'flex', 
+                                        flexDirection: 'column', 
+                                        justifyContent: 'center',
+                                        minHeight: { xs: 'auto', md: '120px' }
+                                    }}>
+                                        <Typography variant="body2" sx={{ opacity: 0.9, mb: 1 }}>
                                             最低時給
                                         </Typography>
-                                        <Typography variant="h5">
+                                        <Typography variant="h5" fontWeight="bold" sx={{ mb: 0.5 }}>
                                             {formatCurrency(comparison.comparisonResult.lowest.hourlyWage?.result?.hourlyWage || 0)}
                                         </Typography>
                                         <Typography variant="body2" sx={{ opacity: 0.8 }}>
                                             {comparison.comparisonResult.lowest.hourlyWage?.label}
                                         </Typography>
                                     </Box>
+                                </Box>
+
+                                {/* 年収差額セクション */}
+                                <Box sx={{ 
+                                    mt: { xs: 2, sm: 3 }, 
+                                    pt: { xs: 2, sm: 3 }, 
+                                    borderTop: '1px solid rgba(255,255,255,0.2)',
+                                    textAlign: 'center'
+                                }}>
+                                    <Typography variant="body2" sx={{ opacity: 0.9, mb: 1 }}>
+                                        年収差額
+                                    </Typography>
+                                    <Typography variant="h5" fontWeight="bold" sx={{ mb: 0.5 }}>
+                                        {formatCurrency(comparison.comparisonResult.differences.maxAnnualIncomeDiff)}
+                                    </Typography>
+                                    <Typography variant="body2" sx={{ opacity: 0.8 }}>
+                                        {formatPercentage(comparison.comparisonResult.differences.maxAnnualIncomeDiffPercent)}
+                                    </Typography>
                                 </Box>
                             </Box>
                         )}

--- a/src/hooks/useComparison.ts
+++ b/src/hooks/useComparison.ts
@@ -105,6 +105,14 @@ export const useComparison = (singleCalculationData?: SalaryCalculationData) => 
       const maxHourlyWageDiff = highestHourlyWage.value - lowestHourlyWage.value;
       const maxAnnualIncomeDiff = highestAnnualIncome.value - lowestAnnualIncome.value;
 
+      // パーセンテージ計算
+      const maxHourlyWageDiffPercent = lowestHourlyWage.value > 0 
+        ? (maxHourlyWageDiff / lowestHourlyWage.value) * 100 
+        : 0;
+      const maxAnnualIncomeDiffPercent = lowestAnnualIncome.value > 0 
+        ? (maxAnnualIncomeDiff / lowestAnnualIncome.value) * 100 
+        : 0;
+
       const result: ComparisonResult = {
         items: itemsWithResults,
         highest: {
@@ -117,7 +125,9 @@ export const useComparison = (singleCalculationData?: SalaryCalculationData) => 
         },
         differences: {
           maxHourlyWageDiff,
+          maxHourlyWageDiffPercent,
           maxAnnualIncomeDiff,
+          maxAnnualIncomeDiffPercent,
         },
       };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -86,7 +86,9 @@ export interface ComparisonResult {
   };
   differences: {
     maxHourlyWageDiff: number;
+    maxHourlyWageDiffPercent: number;
     maxAnnualIncomeDiff: number;
+    maxAnnualIncomeDiffPercent: number;
   };
 }
 


### PR DESCRIPTION
## 概要
時給比較機能の結果表示UIを改善し、パーセンテージ表示を追加することで視認性を向上させる

## 変更点

### UI改善
- 比較結果表示を横並びレイアウトに変更
- カード形式で見やすいデザインに調整
- レスポンシブデザインの最適化

### パーセンテージ表示機能
- 時給差と年収差のパーセンテージ表示を追加
- 数値の視覚的な理解を促進
- ComparisonResult型定義に新しいフィールドを追加

### 型定義の拡張
- `maxHourlyWageDiffPercent`フィールド追加
- `maxAnnualIncomeDiffPercent`フィールド追加

## テスト
- [x] 比較機能の動作確認
- [x] パーセンテージ計算の正確性確認
- [x] レスポンシブデザインの確認
- [x] 型安全性の確認

fixes #33