### PR TITLE
feat: ファビコンの設定 #54

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'" />
     <title>Value-me - 時給計算ツール</title>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- 背景円 -->
+  <circle cx="16" cy="16" r="15" fill="#4F46E5" stroke="#312E81" stroke-width="2"/>
+
+  <!-- 時計の文字盤 -->
+  <circle cx="16" cy="16" r="10" fill="white"/>
+
+  <!-- 時計の針 -->
+  <line x1="16" y1="16" x2="16" y2="10" stroke="#4F46E5" stroke-width="2" stroke-linecap="round"/>
+  <line x1="16" y1="16" x2="20" y2="16" stroke="#4F46E5" stroke-width="1.5" stroke-linecap="round"/>
+
+  <!-- 中心点 -->
+  <circle cx="16" cy="16" r="1.5" fill="#4F46E5"/>
+
+  <!-- 円マーク（通貨記号） -->
+  <text x="16" y="26" font-family="Arial, sans-serif" font-size="8" font-weight="bold" fill="white" text-anchor="middle">¥</text>
+</svg>


### PR DESCRIPTION
## 概要
時給計算アプリのブランディング向上のため、ファビコンを追加しました。

## 変更点

### ファイル追加
- **public/favicon.svg**: 時計と通貨記号（¥）を組み合わせたSVGファビコンを作成
  - メインカラー: 紺色（#4F46E5）
  - 時計の文字盤と針で時給計算をイメージ
  - 通貨記号で給与計算機能を表現

### ファイル変更
- **index.html**: link要素を`/vite.svg`から`/favicon.svg`に変更

## テスト
- [x] ESLintチェック通過（0エラー、既存の警告のみ）
- [x] TypeScriptビルド成功
- [x] 複数サイズ（16px、32px）で自動対応（SVG形式）

## 備考
- SVG形式のため、Retina/高解像度ディスプレイにも対応
- シンプルで視認性の高いデザイン

fixes #54