### PR TITLE
feat: 資格投資の金額修正ボタンの単位を1000円に変更 #65

### DIFF
--- a/src/components/qualification/QualificationCalculator.tsx
+++ b/src/components/qualification/QualificationCalculator.tsx
@@ -24,6 +24,8 @@ import {
 import type { QualificationData, QualificationResult } from '../../types/qualification';
 import { JOB_CATEGORIES, getQualificationsByCategory } from '../../types/qualificationData';
 import { calculateQualificationROI, evaluateQualificationInvestment } from '../../utils/qualificationCalculations';
+import ValidatedInput from '../ValidatedInput';
+import { validateSalary } from '../../utils/validation';
 
 interface QualificationCalculatorProps {
   currentHourlyWage?: number;
@@ -274,55 +276,63 @@ export const QualificationCalculator: React.FC<QualificationCalculatorProps> = (
             </Typography>
 
             {/* 試験料 */}
-            <TextField
-              fullWidth
-              type="number"
+            <ValidatedInput
+              id="exam-fee"
               label="試験料"
               value={data.examFee}
-              onChange={(e) => updateField('examFee', e.target.value)}
-              InputProps={{
-                startAdornment: <InputAdornment position="start">¥</InputAdornment>
-              }}
-              margin="normal"
+              onChange={(value) => updateField('examFee', value)}
+              validator={validateSalary}
+              type="integer"
+              step={1000}
+              unit="円"
+              showIncrementButtons
+              helperText="試験料を入力してください（0円～1億円）"
+              sx={{ mt: 2 }}
             />
 
             {/* 教材費 */}
-            <TextField
-              fullWidth
-              type="number"
+            <ValidatedInput
+              id="material-cost"
               label="教材費"
               value={data.materialCost}
-              onChange={(e) => updateField('materialCost', e.target.value)}
-              InputProps={{
-                startAdornment: <InputAdornment position="start">¥</InputAdornment>
-              }}
-              margin="normal"
+              onChange={(value) => updateField('materialCost', value)}
+              validator={validateSalary}
+              type="integer"
+              step={1000}
+              unit="円"
+              showIncrementButtons
+              helperText="教材費を入力してください（0円～1億円）"
+              sx={{ mt: 2 }}
             />
 
             {/* 講座・研修費 */}
-            <TextField
-              fullWidth
-              type="number"
+            <ValidatedInput
+              id="course-fee"
               label="講座・研修費"
               value={data.courseFee}
-              onChange={(e) => updateField('courseFee', e.target.value)}
-              InputProps={{
-                startAdornment: <InputAdornment position="start">¥</InputAdornment>
-              }}
-              margin="normal"
+              onChange={(value) => updateField('courseFee', value)}
+              validator={validateSalary}
+              type="integer"
+              step={1000}
+              unit="円"
+              showIncrementButtons
+              helperText="講座・研修費を入力してください（0円～1億円）"
+              sx={{ mt: 2 }}
             />
 
             {/* その他費用 */}
-            <TextField
-              fullWidth
-              type="number"
+            <ValidatedInput
+              id="other-costs"
               label="その他費用"
               value={data.otherCosts}
-              onChange={(e) => updateField('otherCosts', e.target.value)}
-              InputProps={{
-                startAdornment: <InputAdornment position="start">¥</InputAdornment>
-              }}
-              margin="normal"
+              onChange={(value) => updateField('otherCosts', value)}
+              validator={validateSalary}
+              type="integer"
+              step={1000}
+              unit="円"
+              showIncrementButtons
+              helperText="その他費用を入力してください（0円～1億円）"
+              sx={{ mt: 2 }}
             />
 
             <Divider sx={{ my: 2 }} />
@@ -333,55 +343,63 @@ export const QualificationCalculator: React.FC<QualificationCalculatorProps> = (
             </Typography>
 
             {/* 現在の資格手当 */}
-            <TextField
-              fullWidth
-              type="number"
+            <ValidatedInput
+              id="current-allowance"
               label="現在の資格手当 (月額)"
               value={data.currentAllowance}
-              onChange={(e) => updateField('currentAllowance', e.target.value)}
-              InputProps={{
-                startAdornment: <InputAdornment position="start">¥</InputAdornment>
-              }}
-              margin="normal"
+              onChange={(value) => updateField('currentAllowance', value)}
+              validator={validateSalary}
+              type="integer"
+              step={1000}
+              unit="円"
+              showIncrementButtons
+              helperText="現在の資格手当を入力してください（0円～1億円）"
+              sx={{ mt: 2 }}
             />
 
             {/* 期待される資格手当 */}
-            <TextField
-              fullWidth
-              type="number"
+            <ValidatedInput
+              id="expected-allowance"
               label="期待される資格手当 (月額)"
               value={data.expectedAllowance}
-              onChange={(e) => updateField('expectedAllowance', e.target.value)}
-              InputProps={{
-                startAdornment: <InputAdornment position="start">¥</InputAdornment>
-              }}
-              margin="normal"
+              onChange={(value) => updateField('expectedAllowance', value)}
+              validator={validateSalary}
+              type="integer"
+              step={1000}
+              unit="円"
+              showIncrementButtons
+              helperText="期待される資格手当を入力してください（0円～1億円）"
+              sx={{ mt: 2 }}
             />
 
             {/* 昇給効果 */}
-            <TextField
-              fullWidth
-              type="number"
+            <ValidatedInput
+              id="salary-increase"
               label="昇給効果 (年額)"
               value={data.salaryIncrease}
-              onChange={(e) => updateField('salaryIncrease', e.target.value)}
-              InputProps={{
-                startAdornment: <InputAdornment position="start">¥</InputAdornment>
-              }}
-              margin="normal"
+              onChange={(value) => updateField('salaryIncrease', value)}
+              validator={validateSalary}
+              type="integer"
+              step={1000}
+              unit="円"
+              showIncrementButtons
+              helperText="昇給効果を入力してください（0円～1億円）"
+              sx={{ mt: 2 }}
             />
 
             {/* 転職時年収アップ */}
-            <TextField
-              fullWidth
-              type="number"
+            <ValidatedInput
+              id="job-change-increase"
               label="転職時年収アップ"
               value={data.jobChangeIncrease}
-              onChange={(e) => updateField('jobChangeIncrease', e.target.value)}
-              InputProps={{
-                startAdornment: <InputAdornment position="start">¥</InputAdornment>
-              }}
-              margin="normal"
+              onChange={(value) => updateField('jobChangeIncrease', value)}
+              validator={validateSalary}
+              type="integer"
+              step={1000}
+              unit="円"
+              showIncrementButtons
+              helperText="転職時年収アップを入力してください（0円～1億円）"
+              sx={{ mt: 2 }}
             />
           </Paper>
         </Box>


### PR DESCRIPTION
## 概要
Issue #65 に対応し、資格投資計算機能の金額入力フィールドに増減ボタンを追加し、その単位を1000円に設定しました。

## 変更点
### QualificationCalculator.tsxの改修
- 8つの金額入力フィールドをMUI TextFieldからValidatedInputに変更:
  1. **試験料（examFee）**
  2. **教材費（materialCost）**
  3. **講座・研修費（courseFee）**
  4. **その他費用（otherCosts）**
  5. **現在の資格手当（currentAllowance）**
  6. **期待される資格手当（expectedAllowance）**
  7. **昇給効果（salaryIncrease）**
  8. **転職時年収アップ（jobChangeIncrease）**

### 機能追加
- 増減ボタンを追加（showIncrementButtons）
- 増減単位を1000円に設定（step={1000}）
- validateSalary関数による入力値検証（0円～1億円）
- ヘルパーテキストによる入力ガイダンス

### UX改善
- 金額入力がより直感的に操作可能
- 大きな金額の入力が容易に（1000円単位での調整）
- キーボードとマウスの両方で効率的な入力が可能

## テスト
- ✅ TypeScript型チェック
- ✅ ESLintチェック（既存の警告のみ、新規エラーなし）
- ✅ ビルドテスト
- ✅ コード品質チェック結果を`logs/code_check_202510192220.md`に出力

### 手動テスト推奨事項
- 各金額フィールドで増減ボタンが表示されることを確認
- 増減ボタンをクリックすると1000円単位で増減することを確認
- 直接入力も可能であることを確認
- バリデーションが正常に動作することを確認（0円～1億円）
- 計算結果が正しく表示されることを確認

fixes #65