### PR TITLE
refactor: 再計算時の白いローディングオーバーレイを削除 #68

### DIFF
--- a/src/components/SalaryCalculator.tsx
+++ b/src/components/SalaryCalculator.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Box, Paper, CircularProgress } from '@mui/material';
+import { Box, Paper } from '@mui/material';
 import type { SalaryCalculationData, CalculationResult } from '../types';
 import BasicInputForm from './BasicInputForm';
 import OptionsForm from './OptionsForm';
@@ -17,16 +17,9 @@ interface SalaryCalculatorProps {
 
 const SalaryCalculator: React.FC<SalaryCalculatorProps> = React.memo(({ data, onChange, onResultChange, hideDynamicHolidaySettings = false, layout = 'vertical' }) => {
   const [useDynamicHolidays, setUseDynamicHolidays] = useState(true);
-  const [isCalculating, setIsCalculating] = useState(false);
 
   useEffect(() => {
     const updateResult = async () => {
-      setIsCalculating(true);
-
-      // 最低表示時間を確保（高速計算でもローディングを視認可能に）
-      const minLoadingTime = 200;
-      const startTime = Date.now();
-
       try {
         let newResult: CalculationResult;
         if (useDynamicHolidays) {
@@ -37,22 +30,12 @@ const SalaryCalculator: React.FC<SalaryCalculatorProps> = React.memo(({ data, on
           newResult = calculateHourlyWage(data);
         }
 
-        // 最低表示時間を確保
-        const elapsedTime = Date.now() - startTime;
-        const remainingTime = Math.max(0, minLoadingTime - elapsedTime);
-
-        if (remainingTime > 0) {
-          await new Promise(resolve => setTimeout(resolve, remainingTime));
-        }
-
         onResultChange(newResult);
       } catch (error) {
         console.warn('動的祝日計算に失敗しました。フォールバック計算を使用します:', error);
         const fallbackResult = calculateHourlyWage(data);
         onResultChange(fallbackResult);
         setUseDynamicHolidays(false);
-      } finally {
-        setIsCalculating(false);
       }
     };
 
@@ -60,31 +43,7 @@ const SalaryCalculator: React.FC<SalaryCalculatorProps> = React.memo(({ data, on
   }, [data, useDynamicHolidays, onResultChange]);
 
   return (
-    <Box sx={{ width: '100%', position: 'relative' }}>
-      {/* ローディングオーバーレイ */}
-      {isCalculating && (
-        <Box
-          sx={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            bgcolor: 'rgba(255, 255, 255, 0.8)',
-            zIndex: 10,
-            borderRadius: 2,
-          }}
-          role="status"
-          aria-live="polite"
-          aria-label="計算中"
-        >
-          <CircularProgress />
-        </Box>
-      )}
-
+    <Box sx={{ width: '100%' }}>
       {/* 入力フォーム */}
       <Box
         sx={{


### PR DESCRIPTION
## 概要
再計算時に画面が白くなるローディングエフェクトを削除し、即座に結果を表示するように改善しました。

## 変更点

### ローディング表示の削除
- 白い半透明背景のローディングオーバーレイを削除（`bgcolor: 'rgba(255, 255, 255, 0.8)'`）
- CircularProgressインジケータを削除
- `isCalculating`状態変数を削除
- 関連するアクセシビリティ属性（`role="status"`, `aria-live="polite"`）も削除

### 計算処理の最適化
- 意図的な最低表示時間処理（200ms遅延）を削除
- 計算結果が即座に表示されるように変更
- 不要な`position: 'relative'`スタイルを削除

### インポートの整理
- `CircularProgress`のインポートを削除

## 期待される効果

- 再計算時の白いフラッシュが完全に消去
- 入力から結果表示までのレスポンスが向上
- 視覚的なストレスがなくなりユーザー体験が改善
- コードがシンプルになり保守性が向上

## テスト

- [x] TypeScript型チェック成功
- [x] ESLintチェック成功（新規警告なし）
- [x] 変更箇所に関する新規エラーなし
- [x] 時給計算が即座に実行され、結果が正しく表示されることを確認

fixes #68