### PR TITLE
feat: レスポンシブレイアウトの改善 #81

### DIFF
--- a/src/components/OptionsForm.tsx
+++ b/src/components/OptionsForm.tsx
@@ -192,8 +192,11 @@ const OptionsForm: React.FC<OptionsFormProps> = React.memo(
 
                                 <Box
                                     sx={{
-                                        display: 'flex',
-                                        flexDirection: 'column',
+                                        display: 'grid',
+                                        gridTemplateColumns: {
+                                            xs: '1fr',
+                                            sm: 'repeat(2, minmax(0, 1fr))',
+                                        },
                                         gap: 2,
                                     }}
                                 >
@@ -349,8 +352,11 @@ const OptionsForm: React.FC<OptionsFormProps> = React.memo(
                             </Typography>
                             <Box
                                 sx={{
-                                    display: 'flex',
-                                    flexDirection: 'column',
+                                    display: 'grid',
+                                    gridTemplateColumns: {
+                                        xs: '1fr',
+                                        sm: 'repeat(2, minmax(0, 1fr))',
+                                    },
                                     gap: 2,
                                 }}
                             >

--- a/src/components/ValidatedInput.tsx
+++ b/src/components/ValidatedInput.tsx
@@ -167,18 +167,23 @@ const ValidatedInput: React.FC<ValidatedInputProps> = ({
     return (
         <Box sx={{
             width: fullWidth ? '100%' : 'auto',
-            display: multiStepButtons && !inlineMultiStepButtons ? 'flex' : 'block',
-            gap: multiStepButtons && !inlineMultiStepButtons ? 1 : 0,
-            alignItems: 'flex-start'
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 0,
         }}>
-            <FormControl
-                fullWidth={fullWidth}
-                variant="outlined"
-                error={hasError}
-                sx={sx}
-            >
-                <InputLabel htmlFor={id}>{label}</InputLabel>
-                <OutlinedInput
+            <Box sx={{
+                display: multiStepButtons && !inlineMultiStepButtons ? 'flex' : 'block',
+                gap: multiStepButtons && !inlineMultiStepButtons ? 1 : 0,
+                alignItems: 'flex-start'
+            }}>
+                <FormControl
+                    fullWidth={fullWidth}
+                    variant="outlined"
+                    error={hasError}
+                    sx={sx}
+                >
+                    <InputLabel htmlFor={id}>{label}</InputLabel>
+                    <OutlinedInput
                     id={id}
                     type="number"
                     value={value || ''}
@@ -377,24 +382,8 @@ const ValidatedInput: React.FC<ValidatedInputProps> = ({
                         step: type === 'float' ? 0.1 : 1,
                     }}
                 />
-                {showHelperText && (
-                    <FormHelperText
-                        sx={{
-                            mx: 0,
-                            maxWidth: 'none',
-                            whiteSpace: 'normal',
-                            wordBreak: 'break-word',
-                        }}
-                    >
-                        {hasError
-                            ? validationResult.errorMessage
-                            : isFocused && helperText
-                            ? helperText
-                            : ''}
-                    </FormHelperText>
-                )}
-            </FormControl>
-            {multiStepButtons && !disabled && !inlineMultiStepButtons && (
+                </FormControl>
+                {multiStepButtons && !disabled && !inlineMultiStepButtons && (
                 <Box
                     sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, flexShrink: 0, height: '56px' }}
                 >
@@ -459,6 +448,26 @@ const ValidatedInput: React.FC<ValidatedInputProps> = ({
                         ))}
                     </Box>
                 </Box>
+            )}
+            </Box>
+            {showHelperText && (
+                <FormHelperText
+                    error={hasError}
+                    sx={{
+                        mx: 0,
+                        mt: 0.5,
+                        maxWidth: 'none',
+                        width: '100%',
+                        whiteSpace: 'normal',
+                        wordBreak: 'break-word',
+                    }}
+                >
+                    {hasError
+                        ? validationResult.errorMessage
+                        : isFocused && helperText
+                        ? helperText
+                        : ''}
+                </FormHelperText>
             )}
         </Box>
     );


### PR DESCRIPTION
## 概要
画面幅に応じたレイアウトの最適化により、モバイルやタブレット等の狭い画面でも使いやすいUIを実現しました。

## 変更内容

### 1. 祝日計算オプションのレスポンシブ対応
- **画面幅が狭い場合（lg未満）**: 祝日計算オプションを一番下に配置
- **画面幅が広い場合（lg以上）**: 祝日計算オプションを基本情報の下に配置

### 2. 各種手当入力欄のhelperText表示改善
- 各種手当とボーナスの入力欄は2列グリッドレイアウトを維持
- helperTextをFormControlの外側に配置することで、オプション機能エリアの横幅いっぱいに表示されるように改善
- テキストの折り返しや見切れがなく、全文が読めるように調整

## 修正ファイル
- [src/components/SalaryCalculator.tsx](src/components/SalaryCalculator.tsx)
- [src/components/OptionsForm.tsx](src/components/OptionsForm.tsx)
- [src/components/ValidatedInput.tsx](src/components/ValidatedInput.tsx)

## テスト内容
- Lint: ✅ 成功（既存の警告のみ）
- ビルド: ✅ 成功

## 関連Issue
- closes #81